### PR TITLE
Fixed StackOverflowException in Channel class

### DIFF
--- a/Channel.cs
+++ b/Channel.cs
@@ -53,8 +53,6 @@ namespace Flow
 
 		bool StepChannel(IGenerator self)
 		{
-			base.Step();
-
 			if (!Active)
 				return true;
 


### PR DESCRIPTION
...Exception.

The Subroutine Step method calls StepChannel, and base.Step is already called
from there.
